### PR TITLE
fix: correctly handle payload value set

### DIFF
--- a/record.go
+++ b/record.go
@@ -67,33 +67,39 @@ func (p Payload) Get(path string) interface{} {
 // TODO: Should we passthrough the gjson helper methods?
 
 type schemaField struct {
-	Field   string `json:"field"`
-	Options bool   `json:"optional"`
-	Type    string `json:"type"`
+	Field    string `json:"field"`
+	Optional bool   `json:"optional"`
+	Type     string `json:"type"`
 }
 
 func (p *Payload) Set(path string, value interface{}) error {
-	// update payload
 	nestedPath := strings.Join([]string{"payload", path}, ".")
+	fieldExists := gjson.Get(string(*p), nestedPath).Exists()
+
+	// update payload
 	val, err := sjson.Set(string(*p), nestedPath, value)
 	if err != nil {
 		return err
 	}
 	*p = []byte(val)
 
-	// update schema
-	schemaField := map[string]interface{}{
-		"field":    path,
-		"optional": true,
-		"type":     "string", // TODO: map Go types to JSON types
-	}
+	// Add schema field if field is new
+	if !fieldExists {
+		fieldType := mapGoToKCDataTypes(val)
 
-	schemaNestedPath := strings.Join([]string{"schema", "fields.-1"}, ".")
-	sval, err := sjson.Set(string(*p), schemaNestedPath, schemaField)
-	if err != nil {
-		return err
+		field := schemaField{
+			Field:    path,
+			Optional: true,
+			Type:     fieldType,
+		}
+
+		schemaNestedPath := strings.Join([]string{"schema", "fields.-1"}, ".")
+		sval, err := sjson.Set(string(*p), schemaNestedPath, field)
+		if err != nil {
+			return err
+		}
+		*p = []byte(sval)
 	}
-	*p = []byte(sval)
 
 	return nil
 }
@@ -101,4 +107,28 @@ func (p *Payload) Set(path string, value interface{}) error {
 type RecordWithError struct {
 	Error error
 	Record
+}
+
+// map Go types to Apache Kafka Connect data types
+func mapGoToKCDataTypes(v interface{}) string {
+	switch v.(type) {
+	case string:
+		return "string"
+	case int8:
+		return "int8"
+	case int16:
+		return "int16"
+	case int, int32:
+		return "int32"
+	case int64:
+		return "int64"
+	case float32:
+		return "float32"
+	case float64:
+		return "float64"
+	case bool:
+		return "boolean"
+	default:
+		return "unsupported"
+	}
 }

--- a/record.go
+++ b/record.go
@@ -82,9 +82,9 @@ func (p *Payload) Set(path string, value interface{}) error {
 	*p = []byte(val)
 
 	// update schema
-	schemaField := map[string]string{
+	schemaField := map[string]interface{}{
 		"field":    path,
-		"optional": "true",
+		"optional": true,
 		"type":     "string", // TODO: map Go types to JSON types
 	}
 

--- a/record_test.go
+++ b/record_test.go
@@ -1,6 +1,9 @@
 package turbine
 
-import "testing"
+import (
+	"github.com/tidwall/gjson"
+	"testing"
+)
 
 func TestPayload_Set(t *testing.T) {
 	type args struct {
@@ -13,15 +16,20 @@ func TestPayload_Set(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{"valid", []byte(`{"schema":{"type":"struct","fields":[{"type":"int32","optional":false,"field":"id"}],"optional":false,"name":"users"},"payload":{"id":15}}`), args{"username", "test"}, false},
+		{"add new", []byte(`{"schema":{"type":"struct","fields":[{"type":"int32","optional":false,"field":"id"}],"optional":false,"name":"users"},"payload":{"id":15}}`), args{"username", "test"}, false},
+		{"update", []byte(`{"schema":{"type":"struct","fields":[{"type":"int32","optional":false,"field":"id"}],"optional":false,"name":"users"},"payload":{"id":15}}`), args{"id", 16}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := tt.p.Set(tt.args.path, tt.args.value); (err != nil) != tt.wantErr {
 				t.Errorf("Set() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if l := len(tt.p.Get("schema.fields").([]interface{})); l != 2 {
-				t.Errorf("Set() fields len = %v, want %v", l, 2)
+
+			if tt.name == "add new" {
+				schemaFields := gjson.Get(string(tt.p), "schema.fields")
+				if l := len(schemaFields.Array()); l != 2 {
+					t.Errorf("Set() fields len = %v, want %v", l, 2)
+				}
 			}
 		})
 	}

--- a/record_test.go
+++ b/record_test.go
@@ -2,6 +2,7 @@ package turbine
 
 import (
 	"github.com/tidwall/gjson"
+	"log"
 	"testing"
 )
 
@@ -11,13 +12,14 @@ func TestPayload_Set(t *testing.T) {
 		value interface{}
 	}
 	tests := []struct {
-		name    string
-		p       Payload
-		args    args
-		wantErr bool
+		name            string
+		p               Payload
+		args            args
+		wantErr         bool
+		schemaFieldsNum int
 	}{
-		{"add new", []byte(`{"schema":{"type":"struct","fields":[{"type":"int32","optional":false,"field":"id"}],"optional":false,"name":"users"},"payload":{"id":15}}`), args{"username", "test"}, false},
-		{"update", []byte(`{"schema":{"type":"struct","fields":[{"type":"int32","optional":false,"field":"id"}],"optional":false,"name":"users"},"payload":{"id":15}}`), args{"id", 16}, false},
+		{"add new", []byte(`{"schema":{"type":"struct","fields":[{"type":"int32","optional":false,"field":"id"}],"optional":false,"name":"users"},"payload":{"id":15}}`), args{"username", "test"}, false, 2},
+		{"update", []byte(`{"schema":{"type":"struct","fields":[{"type":"int32","optional":false,"field":"id"}],"optional":false,"name":"users"},"payload":{"id":15}}`), args{"id", 16}, false, 1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -25,11 +27,10 @@ func TestPayload_Set(t *testing.T) {
 				t.Errorf("Set() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if tt.name == "add new" {
-				schemaFields := gjson.Get(string(tt.p), "schema.fields")
-				if l := len(schemaFields.Array()); l != 2 {
-					t.Errorf("Set() fields len = %v, want %v", l, 2)
-				}
+			schemaFields := gjson.Get(string(tt.p), "schema.fields")
+			if l := len(schemaFields.Array()); l != tt.schemaFieldsNum {
+				log.Printf("p: %+v", string(tt.p))
+				t.Errorf("Set() fields len = %v, want %v", l, tt.schemaFieldsNum)
 			}
 		})
 	}


### PR DESCRIPTION
Addresses the handling of updating an existing field in the record payload correctly.

Previously the associated "schema field" was being duplicated. This additionally correctly sets the data type for many of the native data types.

Fixes: https://github.com/meroxa/turbine-project/issues/191