### PR TITLE
fix: dispatch events to CLI

### DIFF
--- a/.github/workflows/dispatch_cli_dependency.yml
+++ b/.github/workflows/dispatch_cli_dependency.yml
@@ -1,9 +1,11 @@
 name: Remote Dispatch Meroxa CLI Dependency Update
 on:
-  release:
-    types: [prereleased]
+  workflow_dispatch:
+  push:
+    branches:
+      - main
 jobs:
-  dispatch_platform_api:
+  dispatch_cli_dependency:
     runs-on: ubuntu-latest
     steps:
       - name: Shorten sha


### PR DESCRIPTION
Fixes synchronization between CLI and turbine-go:

Tested in https://github.com/meroxa/cli/actions/runs/2378389619

P.S.: I still added `workflow_dispatch ` so we can manually trigger an update from any other branch, but we could restrict this to only what's in the main branch.