### PR TITLE
test(server): adapt test util for new process function signature

### DIFF
--- a/platform/server_test.go
+++ b/platform/server_test.go
@@ -69,8 +69,8 @@ func Test_wrapFrameworkFunc(t *testing.T) {
 		},
 	}
 
-	passthrough := func(rr []turbine.Record) ([]turbine.Record, []turbine.RecordWithError) {
-		return rr, nil
+	passthrough := func(rr []turbine.Record) []turbine.Record {
+		return rr
 	}
 
 	wfn := wrapFrameworkFunc(passthrough)


### PR DESCRIPTION
Part of https://github.com/meroxa/turbine-project/issues/85

While working on the ticket above, I noticed that the [expected return values for the `Process` method had changed recently](https://github.com/meroxa/turbine-go/commit/2cae437cfc85b1953efcdb81d8eaf98e5876b48e#diff-323d89938d680c0b70940a4baf907cadf4c13e36f1bb20514a2a79cc2ff86eabR4) and I think that we would also need to update the server test accordingly.

This should resolve the failing test case

```
./server_test.go:76:26: cannot use passthrough (type func([]turbine.Record) ([]turbine.Record, []turbine.RecordWithError)) as type func([]turbine.Record) []turbine.Record in argument to wrapFrameworkFunc
FAIL	github.com/meroxa/turbine-go/platform [build failed]
```

when running tests for the platform package locally.