### PR TITLE
Accept the old or the new format for API URL

### DIFF
--- a/platform/client.go
+++ b/platform/client.go
@@ -35,6 +35,8 @@ func newClient() (*Client, error) {
 
 	if overrideAPIURL := os.Getenv("API_URL"); overrideAPIURL != "" {
 		options = append(options, meroxa.WithBaseURL(overrideAPIURL))
+	} else if overrideAPIURL := os.Getenv("MEROXA_API_URL"); overrideAPIURL != "" {
+		options = append(options, meroxa.WithBaseURL(overrideAPIURL))
 	}
 
 	options = append(options, meroxa.WithAuthentication(


### PR DESCRIPTION
The CLI accepts either, so the sane thing to do in turbine-go is to also accept either.