### PR TITLE
feat: Create application within the library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,7 @@ test:
 .PHONY: gomod
 gomod:
 	go mod vendor && go mod tidy
+
+.PHONY: lint
+lint:
+	docker run --rm -v $(CURDIR):/app -w /app golangci/golangci-lint:latest golangci-lint run --timeout 5m -v

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/tidwall/gjson v1.14.1
 	github.com/tidwall/sjson v1.2.4
+	github.com/volatiletech/null/v8 v8.1.2
 	golang.org/x/oauth2 v0.0.0-20220630143837-2104d58473e0
 	google.golang.org/grpc v1.47.0
 	google.golang.org/protobuf v1.28.0
@@ -26,7 +27,6 @@ require (
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/volatiletech/inflect v0.0.1 // indirect
-	github.com/volatiletech/null/v8 v8.1.2 // indirect
 	github.com/volatiletech/randomize v0.0.1 // indirect
 	github.com/volatiletech/strmangle v0.0.4 // indirect
 	golang.org/x/net v0.0.0-20220706163947-c90051bbdb60 // indirect

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -9,10 +9,9 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
-
-	"github.com/volatiletech/null/v8"
-
+	
 	"github.com/google/uuid"
+	"github.com/volatiletech/null/v8"
 
 	"github.com/meroxa/meroxa-go/pkg/meroxa"
 	"github.com/meroxa/turbine-go"

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -30,6 +30,8 @@ type Turbine struct {
 	pipelineUUID string
 }
 
+var pipelineUUID string
+
 func New(deploy bool, imageName, gitSha string) Turbine {
 	c, err := newClient()
 	if err != nil {
@@ -70,7 +72,7 @@ func (t *Turbine) createPipeline(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	t.pipelineUUID = p.UUID
+	pipelineUUID = p.UUID
 	return nil
 }
 
@@ -79,7 +81,7 @@ func (t *Turbine) createApplication(ctx context.Context) error {
 		Name:     t.config.Name,
 		Language: "golang",
 		GitSha:   t.gitSha,
-		Pipeline: meroxa.EntityIdentifier{UUID: null.StringFrom(t.pipelineUUID)},
+		Pipeline: meroxa.EntityIdentifier{UUID: null.StringFrom(pipelineUUID)},
 	}
 	_, err := t.client.CreateApplication(ctx, inputCreateApp)
 	return err

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -19,15 +19,14 @@ import (
 )
 
 type Turbine struct {
-	client       *Client
-	functions    map[string]turbine.Function
-	resources    map[string]turbine.Resource
-	deploy       bool
-	imageName    string
-	config       turbine.AppConfig
-	secrets      map[string]string
-	gitSha       string
-	pipelineUUID string
+	client    *Client
+	functions map[string]turbine.Function
+	resources map[string]turbine.Resource
+	deploy    bool
+	imageName string
+	config    turbine.AppConfig
+	secrets   map[string]string
+	gitSha    string
 }
 
 var pipelineUUID string

--- a/platform/platform_test.go
+++ b/platform/platform_test.go
@@ -42,7 +42,7 @@ func TestListResources(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// 2. create a new Turbine client to make methods available for testing
-			turbineMock := New(false, "engine")
+			turbineMock := New(false, "engine", "7c7f63ca-e906-4d0a-a488-65d8dbad1c89")
 			// 3. configure Turbine mock client with sample resources
 			for _, name := range tc.resourceCollection {
 				turbineMock.resources[name] = Resource{}

--- a/runner/platform.go
+++ b/runner/platform.go
@@ -29,7 +29,7 @@ func Start(app turbine.App) {
 	flag.StringVar(&GitSha, "gitsha", "", "git commit sha used to reference the code deployed")
 	flag.Parse()
 
-	pv := platform.New(Deploy, ImageName)
+	pv := platform.New(Deploy, ImageName, GitSha)
 	err := app.Run(pv)
 	if err != nil {
 		log.Fatalln(err)

--- a/runner/platform.go
+++ b/runner/platform.go
@@ -12,11 +12,12 @@ import (
 )
 
 var (
-	ServeFunction string
-	ListFunctions bool
 	Deploy        bool
+	GitSha        string
 	ImageName     string
+	ListFunctions bool
 	ListResources bool
+	ServeFunction string
 )
 
 func Start(app turbine.App) {
@@ -25,6 +26,7 @@ func Start(app turbine.App) {
 	flag.BoolVar(&ListResources, "listresources", false, "list currently used resources")
 	flag.BoolVar(&Deploy, "deploy", false, "deploy the data app")
 	flag.StringVar(&ImageName, "imagename", "", "image name of function image")
+	flag.StringVar(&GitSha, "gitsha", "", "git commit sha used to reference the code deployed")
 	flag.Parse()
 
 	pv := platform.New(Deploy, ImageName)


### PR DESCRIPTION
To be used in a latest CLI release.

This change will no longer require parsing the output from Turbine-Go and will make rollbacks much easier to execute.

⚠️ Still likely needs some catching in case app is created, and a better rollback if something fails ⚠️