### PR TITLE
Add option to enable http transport dump

### DIFF
--- a/platform/client.go
+++ b/platform/client.go
@@ -2,10 +2,12 @@ package platform
 
 import (
 	"fmt"
+	"log"
+	"os"
+
 	"github.com/caarlos0/env/v6"
 	"github.com/meroxa/meroxa-go/pkg/meroxa"
 	"golang.org/x/oauth2"
-	"os"
 )
 
 type ClientConfig struct {
@@ -37,6 +39,10 @@ func newClient() (*Client, error) {
 		options = append(options, meroxa.WithBaseURL(overrideAPIURL))
 	} else if overrideAPIURL := os.Getenv("MEROXA_API_URL"); overrideAPIURL != "" {
 		options = append(options, meroxa.WithBaseURL(overrideAPIURL))
+	}
+
+	if os.Getenv("MEROXA_DEBUG") != "" {
+		options = append(options, meroxa.WithDumpTransport(log.Writer()))
 	}
 
 	options = append(options, meroxa.WithAuthentication(


### PR DESCRIPTION
When `MEROXA_DEBUG` is not empty, enable HTTP transport debug mode in the meroxa-go client.
To see debug as the application is deploying

```
$ MEROXA_DEBUG=1 meroxa apps deploy
...
```