### PR TITLE
Pass app name to turbine 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 meroxa
 examples/simple/simple
+.envrc
 

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
-SHELL=/bin/bash -o pipefail
+.PHONY: build install proto test lint gomod
 
-.PHONY: build
+SHELL                = /bin/bash -o pipefail
+GO_TEST_FLAGS        = -timeout 5m
+GO_TEST_EXTRA_FLAGS ?=
+
 build:
 	go build -mod=vendor .
 
-.PHONY: install
 install:
 	go get -d ./...
 
-.PHONY: proto
 proto:
 	docker run \
 		--rm \
@@ -21,14 +22,13 @@ proto:
 		--lint \
 		-o .
 
-.PHONY: test
 test:
-	go test `go list ./... | grep -v init` -timeout 5m ./...
+	go test `go list ./... | grep -v 'turbine-go\/init'` \
+		$(GO_TEST_FLAGS) $(GO_TEST_EXTRA_FLAGS) \
+		./...
 
-.PHONY: gomod
 gomod:
 	go mod vendor && go mod tidy
 
-.PHONY: lint
 lint:
 	docker run --rm -v $(CURDIR):/app -w /app golangci/golangci-lint:latest golangci-lint run --timeout 5m -v

--- a/config.go
+++ b/config.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -33,7 +32,7 @@ func (c *AppConfig) setPipelineName() {
 	}
 }
 
-var ReadAppConfig = func(appPath string) (AppConfig, error) {
+var ReadAppConfig = func(appName, appPath string) (AppConfig, error) {
 	if appPath == "" {
 		exePath, err := os.Executable()
 		if err != nil {
@@ -42,7 +41,7 @@ var ReadAppConfig = func(appPath string) (AppConfig, error) {
 		appPath = path.Dir(exePath)
 	}
 
-	b, err := ioutil.ReadFile(appPath + "/" + "app.json")
+	b, err := os.ReadFile(appPath + "/" + "app.json")
 	if err != nil {
 		return AppConfig{}, err
 	}
@@ -53,6 +52,9 @@ var ReadAppConfig = func(appPath string) (AppConfig, error) {
 		return AppConfig{}, err
 	}
 
+	if appName != "" {
+		ac.Name = appName
+	}
 	err = ac.validateAppConfig()
 	if err != nil {
 		return AppConfig{}, err

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,110 @@
+package turbine_test
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/meroxa/turbine-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ReadAppConfig(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		appName string
+		appPath string
+		errmsg  string
+	}{
+		{
+			desc:    "reads a valid app config without app name",
+			appName: "testapp",
+			appPath: setupAppJson(t),
+		},
+		{
+			desc:    "reads a valid app config with app name provided",
+			appName: "new-name-app",
+			appPath: setupAppJson(t),
+		},
+		{
+			desc:    "fails to read an config with missing app name",
+			appPath: setupAppJsonMissingField(t),
+			errmsg:  "application name is required",
+		},
+		{
+			desc:    "fails to read bad app json",
+			appPath: setupBadAppJson(t),
+			errmsg:  "invalid character",
+		},
+		{
+			desc:    "fails when app.json is missing",
+			appPath: t.TempDir(),
+			errmsg:  "no such file or directory",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ac, err := turbine.ReadAppConfig(tc.appName, tc.appPath)
+			if tc.errmsg != "" && assert.Error(t, err) {
+				assert.ErrorContains(t, err, tc.errmsg)
+			}
+			if tc.errmsg == "" && assert.NoError(t, err) {
+				assert.Equal(t, ac.Name, tc.appName)
+			}
+		})
+	}
+}
+
+func setupAppJson(t *testing.T) string {
+	tmpdir := t.TempDir()
+	if err := os.WriteFile(
+		path.Join(tmpdir, "app.json"),
+		[]byte(`{
+				  "name": "testapp",
+				  "language": "golang",
+				  "environment": "common",
+				  "resources": {
+				    "source_name": "fixtures/demo-cdc.json"
+				  }
+				}`),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	return tmpdir
+}
+
+func setupAppJsonMissingField(t *testing.T) string {
+	tmpdir := t.TempDir()
+	if err := os.WriteFile(
+		path.Join(tmpdir, "app.json"),
+		[]byte(`{
+				  "language": "golang",
+				  "environment": "common",
+				  "resources": {
+				    "source_name": "fixtures/demo-cdc.json"
+				  }
+				}`),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	return tmpdir
+}
+
+func setupBadAppJson(t *testing.T) string {
+	tmpdir := t.TempDir()
+	if err := os.WriteFile(
+		path.Join(tmpdir, "app.json"),
+		[]byte(`invalid-json`),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	return tmpdir
+
+}

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -20,12 +20,14 @@ type TurbineDockerfileTrait struct {
 }
 
 // CreateDockerfile will be used from the CLI to generate a new Dockerfile based on the app image
-func CreateDockerfile(pwd string) error {
-	ac, err := turbine.ReadAppConfig(pwd)
-	if err != nil {
-		log.Fatalln(err)
+func CreateDockerfile(appName, pwd string) error {
+	if appName == "" {
+		ac, err := turbine.ReadAppConfig(appName, pwd)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		appName = ac.Name
 	}
-	appName := ac.Name
 	fileName := "Dockerfile"
 	t, err := template.ParseFS(templateFS, filepath.Join("template", fileName))
 	if err != nil {

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -1,0 +1,68 @@
+package deploy_test
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/meroxa/turbine-go/deploy"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_CreateDockerfile(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		appName         string
+		expectedAppName string
+		pwd             string
+		errmsg          string
+	}{
+		{
+			desc:            "create dockerfile with provided app name",
+			appName:         "myapp",
+			expectedAppName: "myapp",
+			pwd:             t.TempDir(),
+		},
+		{
+			desc:            "create dockerfile with app name from json.file",
+			expectedAppName: "expectedApp",
+			pwd:             setupAppJson(t),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			dockerfile := path.Join(tc.pwd, "Dockerfile")
+			err := deploy.CreateDockerfile(tc.appName, tc.pwd)
+			if assert.NoError(t, err) && assert.FileExists(t, dockerfile) {
+				v, err := os.ReadFile(dockerfile)
+				if err != nil {
+					t.Fatal(err)
+				}
+				assert.Contains(t, string(v), fmt.Sprintf("COPY %s.cross %s", tc.expectedAppName, tc.expectedAppName))
+				assert.Contains(t, string(v), fmt.Sprintf("ENTRYPOINT [\"/app/%s\", \"--serve\"]", tc.expectedAppName))
+			}
+		})
+	}
+}
+
+func setupAppJson(t *testing.T) string {
+	tmpdir := t.TempDir()
+	if err := os.WriteFile(
+		path.Join(tmpdir, "app.json"),
+		[]byte(`{
+				  "name": "expectedApp",
+				  "language": "golang",
+				  "environment": "common",
+				  "resources": {
+				    "source_name": "fixtures/demo-cdc.json"
+				  }
+				}`),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	return tmpdir
+}

--- a/local/local.go
+++ b/local/local.go
@@ -20,7 +20,7 @@ type Turbine struct {
 }
 
 func New() Turbine {
-	ac, err := turbine.ReadAppConfig("")
+	ac, err := turbine.ReadAppConfig("", "")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
-	
+
 	"github.com/google/uuid"
 	"github.com/volatiletech/null/v8"
 
@@ -30,13 +30,13 @@ type Turbine struct {
 
 var pipelineUUID string
 
-func New(deploy bool, imageName, gitSha string) Turbine {
+func New(deploy bool, imageName, appName, gitSha string) Turbine {
 	c, err := newClient()
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	ac, err := turbine.ReadAppConfig("")
+	ac, err := turbine.ReadAppConfig(appName, "")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/platform/platform_test.go
+++ b/platform/platform_test.go
@@ -35,14 +35,16 @@ func TestListResources(t *testing.T) {
 	// ==========
 	// 1. mock Turbine client with a simplified app configuration handler
 	origReadAppConfig := turbine.ReadAppConfig
-	turbine.ReadAppConfig = func(appPath string) (turbine.AppConfig, error) {
-		return turbine.AppConfig{}, nil
+	turbine.ReadAppConfig = func(appName, appPath string) (turbine.AppConfig, error) {
+		return turbine.AppConfig{
+			Name: appName,
+		}, nil
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// 2. create a new Turbine client to make methods available for testing
-			turbineMock := New(false, "engine", "7c7f63ca-e906-4d0a-a488-65d8dbad1c89")
+			turbineMock := New(false, "engine", "app", "7c7f63ca-e906-4d0a-a488-65d8dbad1c89")
 			// 3. configure Turbine mock client with sample resources
 			for _, name := range tc.resourceCollection {
 				turbineMock.resources[name] = Resource{}
@@ -52,6 +54,7 @@ func TestListResources(t *testing.T) {
 			// ==============
 			result := turbineMock.ListResources()
 			assert.ElementsMatch(t, tc.expectedResourceNames, result)
+			assert.Equal(t, turbineMock.config.Name, "app")
 
 		})
 	}

--- a/runner/platform.go
+++ b/runner/platform.go
@@ -15,6 +15,7 @@ var (
 	Deploy        bool
 	GitSha        string
 	ImageName     string
+	AppName       string
 	ListFunctions bool
 	ListResources bool
 	ServeFunction string
@@ -26,10 +27,12 @@ func Start(app turbine.App) {
 	flag.BoolVar(&ListResources, "listresources", false, "list currently used resources")
 	flag.BoolVar(&Deploy, "deploy", false, "deploy the data app")
 	flag.StringVar(&ImageName, "imagename", "", "image name of function image")
+	flag.StringVar(&AppName, "appname", "", "name of application")
 	flag.StringVar(&GitSha, "gitsha", "", "git commit sha used to reference the code deployed")
 	flag.Parse()
 
-	pv := platform.New(Deploy, ImageName, GitSha)
+	pv := platform.New(Deploy, ImageName, AppName, GitSha)
+
 	err := app.Run(pv)
 	if err != nil {
 		log.Fatalln(err)


### PR DESCRIPTION
The app name from the command line will override whatever is present in the `app.json`. This is to enable feature branches

Part of https://github.com/meroxa/turbine-go/issues/75