### PR TITLE
Expand and change output of `-listresource` from a compiled turbine app.

### DIFF
--- a/platform/platform.go
+++ b/platform/platform.go
@@ -20,7 +20,7 @@ import (
 type Turbine struct {
 	client    *Client
 	functions map[string]turbine.Function
-	resources map[string]turbine.Resource
+	resources []turbine.Resource
 	deploy    bool
 	imageName string
 	config    turbine.AppConfig
@@ -30,7 +30,7 @@ type Turbine struct {
 
 var pipelineUUID string
 
-func New(deploy bool, imageName, appName, gitSha string) Turbine {
+func New(deploy bool, imageName, appName, gitSha string) *Turbine {
 	c, err := newClient()
 	if err != nil {
 		log.Fatalln(err)
@@ -40,10 +40,10 @@ func New(deploy bool, imageName, appName, gitSha string) Turbine {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	return Turbine{
+	return &Turbine{
 		client:    c,
 		functions: make(map[string]turbine.Function),
-		resources: make(map[string]turbine.Resource),
+		resources: []turbine.Resource{},
 		imageName: imageName,
 		deploy:    deploy,
 		config:    ac,
@@ -85,10 +85,13 @@ func (t *Turbine) createApplication(ctx context.Context) error {
 	return err
 }
 
-func (t Turbine) Resources(name string) (turbine.Resource, error) {
+func (t *Turbine) Resources(name string) (turbine.Resource, error) {
 	if !t.deploy {
-		t.resources[name] = Resource{}
-		return Resource{}, nil
+		r := &Resource{
+			Name: name,
+		}
+		t.resources = append(t.resources, r)
+		return r, nil
 	}
 
 	ctx := context.Background()
@@ -109,7 +112,7 @@ func (t Turbine) Resources(name string) (turbine.Resource, error) {
 	log.Printf("retrieved resource %s (%s)", resource.Name, resource.Type)
 
 	u, _ := uuid.Parse(resource.UUID)
-	return Resource{
+	return &Resource{
 		UUID:   u,
 		Name:   resource.Name,
 		Type:   string(resource.Type),
@@ -119,14 +122,20 @@ func (t Turbine) Resources(name string) (turbine.Resource, error) {
 }
 
 type Resource struct {
-	UUID   uuid.UUID
-	Name   string
-	Type   string
-	client meroxa.Client
-	v      Turbine
+	UUID        uuid.UUID
+	Name        string
+	Type        string
+	Source      bool
+	Destination bool
+	Collection  string
+	client      meroxa.Client
+	v           *Turbine
 }
 
-func (r Resource) Records(collection string, cfg turbine.ResourceConfigs) (turbine.Records, error) {
+func (r *Resource) Records(collection string, cfg turbine.ResourceConfigs) (turbine.Records, error) {
+	r.Collection = collection
+	r.Source = true
+
 	if r.client == nil {
 		return turbine.Records{}, nil
 	}
@@ -155,11 +164,13 @@ func (r Resource) Records(collection string, cfg turbine.ResourceConfigs) (turbi
 	}, nil
 }
 
-func (r Resource) Write(rr turbine.Records, collection string) error {
+func (r *Resource) Write(rr turbine.Records, collection string) error {
+	r.Collection = collection
+	r.Destination = true
 	return r.WriteWithConfig(rr, collection, turbine.ResourceConfigs{})
 }
 
-func (r Resource) WriteWithConfig(rr turbine.Records, collection string, cfg turbine.ResourceConfigs) error {
+func (r *Resource) WriteWithConfig(rr turbine.Records, collection string, cfg turbine.ResourceConfigs) error {
 	// bail if dryrun
 	if r.client == nil {
 		return nil
@@ -253,13 +264,30 @@ func (t Turbine) ListFunctions() []string {
 	return funcNames
 }
 
-func (t Turbine) ListResources() []string {
-	var resourceNames []string
-	for name := range t.resources {
-		resourceNames = append(resourceNames, name)
-	}
+type resourceWithCollection struct {
+	Source      bool
+	Destination bool
+	Name        string
+	Collection  string
+}
 
-	return resourceNames
+func (t Turbine) ListResources() ([]resourceWithCollection, error) {
+	var resources []resourceWithCollection
+
+	for i := range t.resources {
+		r, ok := (t.resources[i]).(*Resource)
+		if !ok {
+			return nil, fmt.Errorf("Bad resource type.")
+		}
+		resources = append(resources, resourceWithCollection{
+			Source:      r.Source,
+			Destination: r.Destination,
+			Collection:  r.Collection,
+			Name:        r.Name,
+		})
+
+	}
+	return resources, nil
 }
 
 // RegisterSecret pulls environment variables with the same name and ships them as Env Vars for functions

--- a/platform/platform_test.go
+++ b/platform/platform_test.go
@@ -3,31 +3,50 @@ package platform
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/meroxa/turbine-go"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestListResources(t *testing.T) {
 	testCases := []struct {
-		name                  string
-		resourceCollection    []string
-		expectedResourceNames []string
+		name               string
+		resourceCollection []string
+		turbineResource    map[string]*Resource
 	}{
 		{
-			name:                  "ListResources returns resource names if several resources have been registered",
-			resourceCollection:    []string{"piston", "nozzle"},
-			expectedResourceNames: []string{"piston", "nozzle"},
+			name:               "ListResources returns resource names if several resources have been registered",
+			resourceCollection: []string{"nozzle", "piston"},
+			turbineResource: map[string]*Resource{
+				"nozzle": {
+					Name:        "nozzle",
+					Collection:  "test",
+					Source:      false,
+					Destination: true,
+				},
+				"piston": {
+					Name:        "piston",
+					Collection:  "test 123",
+					Source:      true,
+					Destination: false,
+				},
+			},
 		},
 		{
-			name:                  "ListResources returns resource names if a single resource has been registered",
-			resourceCollection:    []string{"cylinder"},
-			expectedResourceNames: []string{"cylinder"},
+			name:               "ListResources returns resource names if a single resource has been registered",
+			resourceCollection: []string{"cylinder"},
+			turbineResource: map[string]*Resource{
+				"cylinder": {
+					Name:        "cylinder",
+					Collection:  "test",
+					Source:      false,
+					Destination: true,
+				},
+			},
 		},
 		{
-			name:                  "ListResources returns an empty list if no resources have been registered",
-			resourceCollection:    []string{},
-			expectedResourceNames: []string(nil),
+			name:               "ListResources returns an empty list if no resources have been registered",
+			resourceCollection: []string{},
+			turbineResource:    map[string]*Resource{},
 		},
 	}
 
@@ -46,16 +65,29 @@ func TestListResources(t *testing.T) {
 			// 2. create a new Turbine client to make methods available for testing
 			turbineMock := New(false, "engine", "app", "7c7f63ca-e906-4d0a-a488-65d8dbad1c89")
 			// 3. configure Turbine mock client with sample resources
-			for _, name := range tc.resourceCollection {
-				turbineMock.resources[name] = Resource{}
+			for name := range tc.turbineResource {
+				turbineMock.resources = append(turbineMock.resources, tc.turbineResource[name])
 			}
-
 			// Test execution
 			// ==============
-			result := turbineMock.ListResources()
-			assert.ElementsMatch(t, tc.expectedResourceNames, result)
+			result, err := turbineMock.ListResources()
+			if err != nil {
+				t.Errorf("no error expected; got %s", err.Error())
+			}
+
+			if len(result) != len(tc.turbineResource) {
+				t.Errorf("incorrect number of resources returned")
+			}
+
 			assert.Equal(t, turbineMock.config.Name, "app")
 
+			for _, el := range result {
+				assert.Equal(t, tc.turbineResource[el.Name].Name, el.Name)
+				assert.Equal(t, tc.turbineResource[el.Name].Collection, el.Collection)
+				assert.Equal(t, tc.turbineResource[el.Name].Source, el.Source)
+				assert.Equal(t, tc.turbineResource[el.Name].Destination, el.Destination)
+
+			}
 		})
 	}
 

--- a/runner/platform.go
+++ b/runner/platform.go
@@ -4,8 +4,10 @@
 package runner
 
 import (
+	"encoding/json"
 	"flag"
 	"log"
+	"os"
 
 	"github.com/meroxa/turbine-go"
 	"github.com/meroxa/turbine-go/platform"
@@ -54,6 +56,14 @@ func Start(app turbine.App) {
 	}
 
 	if ListResources {
-		log.Printf("available resources: %s", pv.ListResources())
+		rr, err := pv.ListResources()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		enc := json.NewEncoder(os.Stdout)
+		if err := enc.Encode(rr); err != nil {
+			log.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
# Description

New functionality will output JSON by default and it will be an array
composed of resource elements which contain the name of the resource, collection and if
the resource is used as a source or destination.

Expanded output:
```json
$ ./app -listresources | jq .
[
  {
    "Source": true,
    "Destination": false,
    "Name": "db1",
    "Collection": "test"
  },
  {
    "Source": false,
    "Destination": true,
    "Name": "db2",
    "Collection": "test_out"
  }
]

```

Fixes #75 

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit Tests
- [ ] Manual Tests
- [ ] Deployed to staging

