### PR TITLE
Auto-config for Conduit Kafka connectors

### DIFF
--- a/platform/platform.go
+++ b/platform/platform.go
@@ -145,9 +145,15 @@ func (r *Resource) Records(collection string, cfg turbine.ResourceConfigs) (turb
 		return turbine.Records{}, nil
 	}
 
+	connectorConfig := cfg.ToMap()
+	switch r.Type {
+	case "kafka":
+		connectorConfig["conduit"] = "true" // only support Kafka connectors using Conduit so this is safe
+	}
+
 	ci := &meroxa.CreateConnectorInput{
 		ResourceName:  r.Name,
-		Configuration: cfg.ToMap(),
+		Configuration: connectorConfig,
 		Type:          meroxa.ConnectorTypeSource,
 		Input:         collection,
 		PipelineName:  r.v.config.Pipeline,
@@ -183,6 +189,9 @@ func (r *Resource) WriteWithConfig(rr turbine.Records, collection string, cfg tu
 
 	connectorConfig := cfg.ToMap()
 	switch r.Type {
+	case "kafka":
+		connectorConfig["conduit"] = "true" // only support Kafka connectors using Conduit so this is safe
+		connectorConfig["topic"] = strings.ToLower(collection)
 	case "redshift", "postgres", "mysql", "sqlserver": // JDBC sink
 		connectorConfig["table.name.format"] = strings.ToLower(collection)
 	case "mongodb":

--- a/platform/platform_test.go
+++ b/platform/platform_test.go
@@ -153,7 +153,11 @@ func Test_KafkaResourceWrite(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			app := tc.setupApp()
 			kafka1, _ := app.Resources("kafka1")
-			kafka1.Write(turbine.Records{}, "target-collection")
+			err := kafka1.Write(turbine.Records{}, "target-collection")
+			if err != nil {
+				t.Errorf("no error expected; got %s", err.Error())
+			}
+
 		})
 	}
 }

--- a/platform/server.go
+++ b/platform/server.go
@@ -76,7 +76,6 @@ func protoRecordToValveRecord(req *proto.ProcessRecordRequest) []turbine.Record 
 	var rr []turbine.Record
 
 	for _, pr := range req.Records {
-		log.Printf("Received  %v", pr)
 		vr := turbine.Record{
 			Key:       pr.GetKey(),
 			Payload:   turbine.Payload(pr.GetValue()),


### PR DESCRIPTION
Adds auto-config support for Conduit Kafka connectors.

Specifically it sets the `conduit` field to true and maps `collection` to `topic` for Kafka destinations.