### PR TITLE
Add dependabot config to automatically update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Docs: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: ".github:"
+
+  # Maintain dependencies for Go
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "go.mod:"
+
+  # Maintain dependencies for Docker
+  - package-ecosystem: "docker"
+    directory: "/deploy/template"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "Dockerfile:"


### PR DESCRIPTION
Copied from Conduit, cuz they are ahead of the curve. Dependabot should open PRs as new versions are found weekly.

Related to https://github.com/meroxa/engineering/issues/24