### PR TITLE
Suppress error logging for serving function when receiving sigterm

### DIFF
--- a/runner/platform.go
+++ b/runner/platform.go
@@ -72,7 +72,7 @@ func Start(app turbine.App) {
 			log.Fatalf("invalid or missing function %s", ServeFunction)
 		}
 		err := platform.ServeFunc(fn)
-		if err != nil {
+		if err != nil && err.Error() != "received signal terminated" {
 			log.Fatalf("unable to serve function %s; error: %s", ServeFunction, err)
 		}
 	}


### PR DESCRIPTION
Currently when `FuncServ` receives `SIGTERM` it terminates the goroutine (as expected) but returns an error that is then logged out.

The error message is misleading as this is innocuous and happens when a function is spun down.