### PR TITLE
Rename ResourceConfigs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ meroxa
 examples/simple/simple
 .envrc
 .vscode
+.idea

--- a/init/template/app.go
+++ b/init/template/app.go
@@ -42,7 +42,7 @@ func (a App) Run(v turbine.Turbine) error {
 	// If a configuration is needed for your source,
 	// you can pass it as a second argument to the `Records` function. For example:
 	//
-	// source.Records("collection_name", turbine.ResourceConfigs{turbine.ResourceConfig{Field: "incrementing.field.name", Value:"id"}})
+	// source.Records("collection_name", turbine.ConnectionOptions{turbine.ResourceConfig{Field: "incrementing.field.name", Value:"id"}})
 
 	rr, err := source.Records("collection_name", nil)
 	if err != nil {
@@ -74,7 +74,7 @@ func (a App) Run(v turbine.Turbine) error {
 	// dest.WriteWithConfig(
 	//  res,
 	//  "my-archive",
-	//  turbine.ResourceConfigs{turbine.ResourceConfig{Field: "buffer.flush.time", Value: "10"}}
+	//  turbine.ConnectionOptions{turbine.ResourceConfig{Field: "buffer.flush.time", Value: "10"}}
 	// )
 
 	err = dest.Write(res, "collection_archive")

--- a/local/local.go
+++ b/local/local.go
@@ -54,7 +54,7 @@ type Resource struct {
 	fixturesPath string
 }
 
-func (r Resource) Records(collection string, cfg turbine.ResourceConfigs) (turbine.Records, error) {
+func (r Resource) Records(collection string, cfg turbine.ConnectionOptions) (turbine.Records, error) {
 	binPath, err := os.Executable()
 	if err != nil {
 		return turbine.Records{}, err
@@ -68,13 +68,13 @@ func (r Resource) Records(collection string, cfg turbine.ResourceConfigs) (turbi
 	return readFixtures(pwd, collection)
 }
 
-func (r Resource) WriteWithConfig(rr turbine.Records, collection string, cfg turbine.ResourceConfigs) error {
+func (r Resource) WriteWithConfig(rr turbine.Records, collection string, cfg turbine.ConnectionOptions) error {
 	prettyPrintRecords(r.Name, collection, turbine.GetRecords(rr))
 	return nil
 }
 
 func (r Resource) Write(rr turbine.Records, collection string) error {
-	return r.WriteWithConfig(rr, collection, turbine.ResourceConfigs{})
+	return r.WriteWithConfig(rr, collection, turbine.ConnectionOptions{})
 }
 
 func prettyPrintRecords(name string, collection string, rr []turbine.Record) {

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -137,7 +137,7 @@ type Resource struct {
 	v           *Turbine
 }
 
-func (r *Resource) Records(collection string, cfg turbine.ResourceConfigs) (turbine.Records, error) {
+func (r *Resource) Records(collection string, cfg turbine.ConnectionOptions) (turbine.Records, error) {
 	r.Collection = collection
 	r.Source = true
 
@@ -176,10 +176,10 @@ func (r *Resource) Records(collection string, cfg turbine.ResourceConfigs) (turb
 }
 
 func (r *Resource) Write(rr turbine.Records, collection string) error {
-	return r.WriteWithConfig(rr, collection, turbine.ResourceConfigs{})
+	return r.WriteWithConfig(rr, collection, turbine.ConnectionOptions{})
 }
 
-func (r *Resource) WriteWithConfig(rr turbine.Records, collection string, cfg turbine.ResourceConfigs) error {
+func (r *Resource) WriteWithConfig(rr turbine.Records, collection string, cfg turbine.ConnectionOptions) error {
 	// bail if dryrun
 	if r.client == nil {
 		return nil

--- a/platform/v2/resources.go
+++ b/platform/v2/resources.go
@@ -44,7 +44,7 @@ func (t *Turbine) ListResources() ([]platform.ResourceWithCollection, error) {
 	return resources, nil
 }
 
-func (r *Resource) Records(collection string, cfg turbine.ResourceConfigs) (turbine.Records, error) {
+func (r *Resource) Records(collection string, cfg turbine.ConnectionOptions) (turbine.Records, error) {
 	records := turbine.Records{}
 	if collection == "" {
 		return records, fmt.Errorf("please provide a collection name to Records()")
@@ -76,10 +76,10 @@ func (r *Resource) Write(rr turbine.Records, collection string) error {
 	if collection == "" {
 		return fmt.Errorf("please provide a collection name to Write()")
 	}
-	return r.WriteWithConfig(rr, collection, turbine.ResourceConfigs{})
+	return r.WriteWithConfig(rr, collection, turbine.ConnectionOptions{})
 }
 
-func (r *Resource) WriteWithConfig(rr turbine.Records, collection string, cfg turbine.ResourceConfigs) error {
+func (r *Resource) WriteWithConfig(rr turbine.Records, collection string, cfg turbine.ConnectionOptions) error {
 	// This function may be called zero or more times.
 	if collection == "" {
 		return fmt.Errorf("please provide a collection name to WriteWithConfig()")

--- a/platform/v2/resources_test.go
+++ b/platform/v2/resources_test.go
@@ -64,7 +64,7 @@ func TestListResources(t *testing.T) {
 func TestRecords(t *testing.T) {
 	type parameters struct {
 		Collection string
-		Cfg        turbine.ResourceConfigs
+		Cfg        turbine.ConnectionOptions
 	}
 
 	tests := []struct {
@@ -76,7 +76,7 @@ func TestRecords(t *testing.T) {
 			description: "Fail to add a source connector with an empty collection",
 			input: parameters{
 				Collection: "",
-				Cfg:        turbine.ResourceConfigs{{Field: "a", Value: "b"}, {Field: "c", Value: "d"}},
+				Cfg:        turbine.ConnectionOptions{{Field: "a", Value: "b"}, {Field: "c", Value: "d"}},
 			},
 			err: fmt.Errorf("please provide a collection name to Records()"),
 		},
@@ -84,7 +84,7 @@ func TestRecords(t *testing.T) {
 			description: "Successfully add one source connector",
 			input: parameters{
 				Collection: "collection1",
-				Cfg:        turbine.ResourceConfigs{{Field: "a", Value: "b"}, {Field: "c", Value: "d"}},
+				Cfg:        turbine.ConnectionOptions{{Field: "a", Value: "b"}, {Field: "c", Value: "d"}},
 			},
 			err: nil,
 		},
@@ -92,7 +92,7 @@ func TestRecords(t *testing.T) {
 			description: "Fail to add a second source connector",
 			input: parameters{
 				Collection: "collection2",
-				Cfg:        turbine.ResourceConfigs{{Field: "a", Value: "b"}, {Field: "c", Value: "d"}},
+				Cfg:        turbine.ConnectionOptions{{Field: "a", Value: "b"}, {Field: "c", Value: "d"}},
 			},
 			err: fmt.Errorf("only one call to Records() is allowed per Meroxa Data Application"),
 		},
@@ -163,7 +163,7 @@ func TestWrite(t *testing.T) {
 func TestWriteWithConfig(t *testing.T) {
 	type parameters struct {
 		Collection string
-		Cfg        turbine.ResourceConfigs
+		Cfg        turbine.ConnectionOptions
 	}
 
 	tests := []struct {
@@ -180,10 +180,10 @@ func TestWriteWithConfig(t *testing.T) {
 			description: "Successfully add multiple destination connectors",
 			input: []parameters{
 				{"collection1",
-					turbine.ResourceConfigs{{Field: "a", Value: "b"}, {Field: "c", Value: "d"}},
+					turbine.ConnectionOptions{{Field: "a", Value: "b"}, {Field: "c", Value: "d"}},
 				},
 				{"collection2",
-					turbine.ResourceConfigs{{Field: "e", Value: "f"}, {Field: "g", Value: "h"}},
+					turbine.ConnectionOptions{{Field: "e", Value: "f"}, {Field: "g", Value: "h"}},
 				},
 			},
 			err: nil,

--- a/resource.go
+++ b/resource.go
@@ -10,8 +10,8 @@ type Resource interface {
 // In previous version of turbine-go they were used as
 // actual type name.
 
-type ResourceConfigs ConnectionOptions
-type ResourceConfig ConnectionOption
+type ResourceConfigs = ConnectionOptions
+type ResourceConfig = ConnectionOption
 
 type ConnectionOption struct {
 	Field string

--- a/resource.go
+++ b/resource.go
@@ -1,19 +1,26 @@
 package turbine
 
 type Resource interface {
-	Records(collection string, cfg ResourceConfigs) (Records, error)
+	Records(collection string, cfg ConnectionOptions) (Records, error)
 	Write(records Records, collection string) error
-	WriteWithConfig(records Records, collection string, cfg ResourceConfigs) error
+	WriteWithConfig(records Records, collection string, cfg ConnectionOptions) error
 }
 
-type ResourceConfig struct {
+// The following aliases exist for backward compatibility.
+// In previous version of turbine-go they were used as
+// actual type name.
+
+type ResourceConfigs ConnectionOptions
+type ResourceConfig ConnectionOption
+
+type ConnectionOption struct {
 	Field string
 	Value string
 }
 
-type ResourceConfigs []ResourceConfig
+type ConnectionOptions []ConnectionOption
 
-func (cfg ResourceConfigs) ToMap() map[string]interface{} {
+func (cfg ConnectionOptions) ToMap() map[string]interface{} {
 	m := make(map[string]interface{})
 	for _, rc := range cfg {
 		m[rc.Field] = rc.Value

--- a/resource.go
+++ b/resource.go
@@ -10,7 +10,10 @@ type Resource interface {
 // In previous version of turbine-go they were used as
 // actual type name.
 
+// Deprecated: Use ConnectionOptions instead
 type ResourceConfigs = ConnectionOptions
+
+// Deprecated: Use ConnectionOption instead
 type ResourceConfig = ConnectionOption
 
 type ConnectionOption struct {


### PR DESCRIPTION
Renames `ResourceConfigs` to `ConnectionOptions` (suggested by @ahmeroxa). Also adds a type alias, to avoid breaking existing code.

Fixes #105.