### PR TITLE
Turbine collaboration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/jeremywohl/flatten v1.0.1
-	github.com/meroxa/meroxa-go v0.0.0-20221013173722-55761ea28c2f
+	github.com/meroxa/meroxa-go v0.0.0-20221017201107-221ac11788e1
 	github.com/meroxa/turbine-core v0.0.0-20220922191011-28d1085ab969
 	github.com/oklog/run v1.1.1-0.20200508094559-c7096881717e
 	github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/jeremywohl/flatten v1.0.1 h1:LrsxmB3hfwJuE+ptGOijix1PIfOoKLJ3Uee/mzbg
 github.com/jeremywohl/flatten v1.0.1/go.mod h1:4AmD/VxjWcI5SRB0n6szE2A6s2fsNHDLO0nAlMHgfLQ=
 github.com/meroxa/meroxa-go v0.0.0-20221013173722-55761ea28c2f h1:EtukvShMuDPtVPrbc5qCVjdSebxC5yEHugydAWTVoFE=
 github.com/meroxa/meroxa-go v0.0.0-20221013173722-55761ea28c2f/go.mod h1:OdTP4P/yHcTAqOE86kDXoTTLqC1Vj+/PFMG41kOcmhI=
+github.com/meroxa/meroxa-go v0.0.0-20221017201107-221ac11788e1 h1:vZVp1wAZgeC25nwBzO/TNT57uEV2yeTpzc8eMnbwzug=
+github.com/meroxa/meroxa-go v0.0.0-20221017201107-221ac11788e1/go.mod h1:OdTP4P/yHcTAqOE86kDXoTTLqC1Vj+/PFMG41kOcmhI=
 github.com/meroxa/turbine-core v0.0.0-20220922191011-28d1085ab969 h1:XSjpmRxrIttZuAz+wpoH+jY4cyYoWl9lVrsM3LFFQ5o=
 github.com/meroxa/turbine-core v0.0.0-20220922191011-28d1085ab969/go.mod h1:YN5vKxT72JnTSHOReBwZiQXRf8+uzSS/eWkFC4Onsj0=
 github.com/oklog/run v1.1.1-0.20200508094559-c7096881717e h1:bxQ+jj+8fdl9112bovUjD/14jj/uboMqjyVoFkqrdGg=

--- a/platform/client.go
+++ b/platform/client.go
@@ -55,7 +55,9 @@ func NewClient() (*Client, error) {
 		onTokenRefreshed,
 	))
 
-	options = append(options, meroxa.WithAccountUUID(os.Getenv("MEROXA_ACCOUNT_UUID")))
+	if accountUUID := os.Getenv("MEROXA_ACCOUNT_UUID"); accountUUID != "" {
+		options = append(options, meroxa.WithAccountUUID(accountUUID))
+	}
 	mc, err := meroxa.New(options...)
 	return &Client{mc}, err
 }

--- a/platform/client.go
+++ b/platform/client.go
@@ -55,6 +55,7 @@ func NewClient() (*Client, error) {
 		onTokenRefreshed,
 	))
 
+	options = append(options, meroxa.WithAccountUUID(os.Getenv("MEROXA_ACCOUNT_UUID")))
 	mc, err := meroxa.New(options...)
 	return &Client{mc}, err
 }

--- a/runner/platform.go
+++ b/runner/platform.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"flag"
 	"log"
-	"os"
+	"strings"
 
 	"github.com/meroxa/turbine-go"
 	"github.com/meroxa/turbine-go/platform"
@@ -77,7 +77,7 @@ func Start(app turbine.App) {
 	}
 
 	if ListFunctions {
-		log.Printf("available functions: %s", pv.ListFunctions())
+		log.Printf("turbine-response: [%s]", strings.Join(pv.ListFunctions(), ", "))
 	}
 
 	if ListResources {
@@ -86,9 +86,10 @@ func Start(app turbine.App) {
 			log.Fatal(err)
 		}
 
-		enc := json.NewEncoder(os.Stdout)
-		if err := enc.Encode(rr); err != nil {
+		bytes, err := json.Marshal(rr)
+		if err != nil {
 			log.Fatal(err)
 		}
+		log.Printf("turbine-response: %s\n", string(bytes))
 	}
 }


### PR DESCRIPTION
fixes https://github.com/meroxa/turbine-project/issues/276

Pulls in meroxa-go that supports setting Meroxa-Account-UUID header
makes responses to CLI more stable by always starting with the turbine-response tag