### PR TITLE
fix: dockerfile for turbine-core

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -36,7 +36,7 @@ func CreateDockerfile(appName, pwd string) error {
 
 	dockerfile := TurbineDockerfileTrait{
 		AppName:   appName,
-		GoVersion: "1.17",
+		GoVersion: "1.20",
 	}
 
 	f, err := os.Create(filepath.Join(pwd, fileName))

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -41,7 +41,7 @@ func Test_CreateDockerfile(t *testing.T) {
 					t.Fatal(err)
 				}
 				assert.Contains(t, string(v), fmt.Sprintf("COPY %s.cross %s", tc.expectedAppName, tc.expectedAppName))
-				assert.Contains(t, string(v), fmt.Sprintf("ENTRYPOINT [\"/app/%s\", \"--serve\"]", tc.expectedAppName))
+				assert.Contains(t, string(v), fmt.Sprintf("ENTRYPOINT [\"/app/%s\"]", tc.expectedAppName))
 			}
 		})
 	}

--- a/deploy/template/Dockerfile
+++ b/deploy/template/Dockerfile
@@ -3,4 +3,4 @@ USER nobody
 WORKDIR /app
 COPY app.json /app
 COPY {{.AppName}}.cross {{.AppName}}
-ENTRYPOINT ["/app/{{.AppName}}", "--serve"]
+ENTRYPOINT ["/app/{{.AppName}}"]


### PR DESCRIPTION
## Description of change

Part of https://github.com/meroxa/cli/issues/687

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ] Local deployment

## Demo

**Before**

```
# Logs for anonymize-ffa1a8f6 function

[2023-04-25T14:37:37Z] flag provided but not defined: -serve
[2023-04-25T14:37:37Z] Usage of /app/simple:
[2023-04-25T14:37:37Z]   -gitsha string
[2023-04-25T14:37:37Z]     	git commit sha used to reference the code deployed
[2023-04-25T14:37:37Z]   -turbine-core-server string
[2023-04-25T14:37:37Z]     	address of the turbine core server
[2023-04-25T14:38:20Z] flag provided but not defined: -serve
[2023-04-25T14:38:20Z] Usage of /app/simple:
[2023-04-25T14:38:20Z]   -gitsha string
[2023-04-25T14:38:20Z]     	git commit sha used to reference the code deployed
[2023-04-25T14:38:20Z]   -turbine-core-server string
[2023-04-25T14:38:20Z]     	address of the turbine core server
[2023-04-25T14:39:06Z] flag provided but not defined: -serve
[2023-04-25T14:39:06Z] Usage of /app/simple:
[2023-04-25T14:39:06Z]   -gitsha string
[2023-04-25T14:39:06Z]     	git commit sha used to reference the code deployed
[2023-04-25T14:39:06Z]   -turbine-core-server string
[2023-04-25T14:39:06Z]     	address of the turbine core server
[2023-04-25T14:40:31Z] flag provided but not defined: -serve
[2023-04-25T14:40:31Z] Usage of /app/simple:
[2023-04-25T14:40:31Z]   -gitsha string
[2023-04-25T14:40:31Z]     	git commit sha used to reference the code deployed
[2023-04-25T14:40:31Z]   -turbine-core-server string
[2023-04-25T14:40:31Z]     	address of the turbine core server
[2023-04-25T14:43:19Z] flag provided but not defined: -serve
[2023-04-25T14:43:19Z] Usage of /app/simple:
[2023-04-25T14:43:19Z]   -gitsha string
[2023-04-25T14:43:19Z]     	git commit sha used to reference the code deployed
[2023-04-25T14:43:19Z]   -turbine-core-server string
[2023-04-25T14:43:19Z]     	address of the turbine core server
```

**Now**


