### PR TITLE
Make sure Function output goes to stdout by default

### DIFF
--- a/pkg/turbine/cmd/cmd.go
+++ b/pkg/turbine/cmd/cmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"log"
+	"os"
 
 	sdk "github.com/meroxa/turbine-go/pkg/turbine"
 	"github.com/meroxa/turbine-go/pkg/turbine/build"
@@ -31,6 +32,7 @@ func Start(app sdk.App) {
 		ctx = context.Background()
 		cmd = parseFlags()
 	)
+	log.SetOutput(os.Stdout)
 
 	switch cmd {
 	case serverCmdName:


### PR DESCRIPTION
## Description of change

For some reason, the logger seems to default to stderr.  This is specifically a problem with a Function that has logs that should go to stdout but go to stderr instead. Then the CLI assumes things are failing. 

Fixes https://github.com/meroxa/turbine-go/issues/162

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube

## Demo

Demo is with the CLI changes that check stderr so as to set the exit code properly

first run is without this turbine-go change, second run is with it

![Screenshot from 2023-06-13 12-44-38](https://github.com/meroxa/turbine-go/assets/12731615/42f2c420-70f3-4c7a-a54c-21c3be846bce)


## Additional references

<!-- Post any additional links (if appropriate) below -->
