### PR TITLE
Dependency paths are not OS specific

### DIFF
--- a/pkg/turbine/build/builder.go
+++ b/pkg/turbine/build/builder.go
@@ -111,7 +111,7 @@ func turbineGoVersion(ctx context.Context) (string, error) {
 	}
 
 	for _, m := range bi.Deps {
-		if m.Path == filepath.Join("github.com", "meroxa", "turbine-go", "v2") {
+		if m.Path == "github.com/meroxa/turbine-go/v2" { // this path is the same, regardless of OS
 			return parse(m.Version), nil
 		}
 	}


### PR DESCRIPTION
## Description of change

Go dependencies have backslashes, regardless of OS

https://github.com/meroxa/acceptance/actions/runs/5328348011/jobs/9652857920#step:16:395

Error: 2023/06/20 23:05:26 unable to find turbine-go in modules
        exit status 1

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->
